### PR TITLE
Fix cover page link

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,4 +3,4 @@ layout: default
 title: index
 ---
 
-[![cover.svg](cover.svg)](00)
+[![cover.svg](cover.svg)](00_about)


### PR DESCRIPTION
The cover page link currently leads to a 404. Hopefully this is the correct syntax to fix that.